### PR TITLE
Refactor: Consolidate Flutter dependency installation into setup action

### DIFF
--- a/.github/workflows/distribute.yml
+++ b/.github/workflows/distribute.yml
@@ -21,16 +21,13 @@ jobs:
         uses: ./.github/actions/setup-flutter
 
       - name: Build APK
-        run: flutter build apk --debug
-
-      - name: Build APK
         run: flutter build apk --release
 
       - name: Upload APK to Firebase App Distribution
         uses: wzieba/Firebase-Distribution-Github-Action@v1
         with:
           appId: ${{ secrets.FIREBASE_APP_ID }}
-          token: ${{ secrets.FIREBASE_TOKEN }}
+          serviceCredentialsFileContent: ${{ secrets.CREDENTIALS_FILE }}
           groups: codandotv-creators
           file: build/app/outputs/apk/release/app-release.apk
           releaseNotes: ${{ github.event.inputs.release-notes }}


### PR DESCRIPTION
Moves the steps for installing Flutter dependencies and generating files from a separate `setup-flutter-deps` action into the main `setup-flutter` action. This simplifies the GitHub Actions workflows by removing the need for a separate action call.