### PR TITLE
Refactor TasksListWidget and update version

### DIFF
--- a/lib/ui/components/widgets/checklist/checklist_full_widget.dart
+++ b/lib/ui/components/widgets/checklist/checklist_full_widget.dart
@@ -5,7 +5,7 @@ import 'package:todoapp/data/model/tasks_complete_status.dart';
 import 'package:todoapp/ui/components/remove_task_dialog_builder.dart';
 import 'package:todoapp/ui/components/tasks_view_model/tasks_viewmodel.dart';
 import 'package:todoapp/ui/components/widgets/checklist/checklist_item_widget.dart';
-import 'package:todoapp/ui/components/widgets/task/taskslist/tasks_list_widget.dart';
+import 'package:todoapp/ui/components/widgets/tasks_list_widget.dart';
 import 'package:todoapp/ui/l10n/app_localizations.dart';
 import 'package:todoapp/ui/todo_app_router_config.gr.dart';
 import 'package:todoapp/util/di/dependency_startup_launcher.dart';

--- a/lib/ui/components/widgets/task/taskslist/tasks_list_widget.dart
+++ b/lib/ui/components/widgets/task/taskslist/tasks_list_widget.dart
@@ -49,8 +49,7 @@ class TasksListWidget extends StatelessWidget {
         ),
       );
     } else {
-      child = Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
+      Widget header = Column(
         children: [
           ProgressWidget(
             progress: progress,
@@ -60,20 +59,20 @@ class TasksListWidget extends StatelessWidget {
             onClick: () {
               onCompleteButtonAction();
             },
-          ),
-          Expanded(
-            child: ReorderableListView.builder(
-              onReorder: onReorder,
-              padding: const EdgeInsets.only(
-                bottom: 120.0,
-              ),
-              itemBuilder: (context, index) => _buildTaskCellWidget(
-                tasks[index],
-              ),
-              itemCount: tasks.length,
-            ),
-          ),
+          )
         ],
+      );
+
+      child = ReorderableListView.builder(
+        header: header,
+        onReorder: onReorder,
+        padding: const EdgeInsets.only(
+          bottom: 120.0,
+        ),
+        itemBuilder: (context, index) => _buildTaskCellWidget(
+          tasks[index],
+        ),
+        itemCount: tasks.length,
       );
     }
 

--- a/lib/ui/components/widgets/tasks_list_widget.dart
+++ b/lib/ui/components/widgets/tasks_list_widget.dart
@@ -50,6 +50,7 @@ class TasksListWidget extends StatelessWidget {
       );
     } else {
       Widget header = Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           ProgressWidget(
             progress: progress,

--- a/lib/ui/screens/tasks/tasks_screen.dart
+++ b/lib/ui/screens/tasks/tasks_screen.dart
@@ -7,7 +7,7 @@ import 'package:todoapp/ui/components/remove_task_dialog_builder.dart';
 import 'package:todoapp/ui/components/tasks_view_model/tasks_screen_state.dart';
 import 'package:todoapp/ui/components/tasks_view_model/tasks_viewmodel.dart';
 import 'package:todoapp/ui/components/widgets/custom_app_bar_widget.dart';
-import 'package:todoapp/ui/components/widgets/task/taskslist/tasks_list_widget.dart';
+import 'package:todoapp/ui/components/widgets/tasks_list_widget.dart';
 import 'package:todoapp/ui/l10n/app_localizations.dart';
 import 'package:todoapp/ui/screens/tasks/tasks_screen_callbacks.dart';
 import 'package:todoapp/ui/todo_app_router_config.gr.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.2.2
+version: 1.2.3
 
 environment:
   sdk: ^3.5.0


### PR DESCRIPTION
Refactor the `TasksListWidget` to include a header in the `ReorderableListView` and simplify its layout. Update import statements for correct paths and bump the version to 1.2.3 in `pubspec.yaml`.